### PR TITLE
Default config should be defaults instead of overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,15 +26,16 @@ impl Config {
             path
         };
 
-        cfg.apply_config_file(env::home_dir().unwrap().join(CONFIG_FILENAME));
         loop {
             let cfg_path = path.join(CONFIG_FILENAME);
             cfg.apply_config_file(&cfg_path);
             path = match path.parent() {
                 Some(p) => p,
-                None => return cfg,
+                None => break,
             };
         }
+        cfg.apply_config_file(env::home_dir().unwrap().join(CONFIG_FILENAME));
+        cfg
     }
 
     fn apply_config_file<P>(&mut self, cfg_path: P)


### PR DESCRIPTION
Fix #3
Now we'll use the default config file as a set of defaults instead of overrides.
